### PR TITLE
Handle unlimited pagination when limit is zero

### DIFF
--- a/controllers/invoice_controller.go
+++ b/controllers/invoice_controller.go
@@ -72,8 +72,16 @@ func (ctrl *InvoiceController) FilterByDate(c *fiber.Ctx) error {
 	fromStr := c.Query("from")
 	toStr := c.Query("to")
 	code := c.Query("code")
+	pageStr := c.Query("page")
+	limitStr := c.Query("limit")
+
 	page := c.QueryInt("page", 1)
 	limit := c.QueryInt("limit", 10)
+
+	// Nếu không gửi limit hoặc giá trị bằng 0 thì lấy toàn bộ danh sách
+	if limitStr == "" || limit == 0 {
+		limit = 0
+	}
 
 	var fromTime, toTime time.Time
 	filterByDate := fromStr != "" && toStr != ""

--- a/controllers/product_controller.go
+++ b/controllers/product_controller.go
@@ -73,8 +73,8 @@ func (ctrl *ProductController) List(c *fiber.Ctx) error {
 	page := c.QueryInt("page", 1)
 	limit := c.QueryInt("limit", 10)
 
-	// Nếu không truyền page và limit thì trả về toàn bộ danh sách
-	if pageStr == "" && limitStr == "" {
+	// Nếu không gửi limit hoặc giá trị bằng 0 thì trả về toàn bộ danh sách
+	if limitStr == "" || limit == 0 {
 		limit = 0
 	}
 


### PR DESCRIPTION
## Summary
- make product pagination ignore limit when absent or 0
- make invoice pagination ignore limit when absent or 0
- skip skip/limit in invoice repo when limit <= 0

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684cda3fe7ac8331972a37214dfb48dc