### PR TITLE
Fix build failure due to unused variables

### DIFF
--- a/controllers/invoice_controller.go
+++ b/controllers/invoice_controller.go
@@ -72,7 +72,6 @@ func (ctrl *InvoiceController) FilterByDate(c *fiber.Ctx) error {
 	fromStr := c.Query("from")
 	toStr := c.Query("to")
 	code := c.Query("code")
-	pageStr := c.Query("page")
 	limitStr := c.Query("limit")
 
 	page := c.QueryInt("page", 1)

--- a/controllers/product_controller.go
+++ b/controllers/product_controller.go
@@ -67,7 +67,6 @@ func (ctrl *ProductController) Delete(c *fiber.Ctx) error {
 // List trả về danh sách sản phẩm có phân trang & tìm kiếm
 // Method: GET /api/products?page=1&limit=10&search=tên
 func (ctrl *ProductController) List(c *fiber.Ctx) error {
-	pageStr := c.Query("page")
 	limitStr := c.Query("limit")
 
 	page := c.QueryInt("page", 1)


### PR DESCRIPTION
## Summary
- remove unused `pageStr` variable in invoice controller
- remove unused `pageStr` variable in product controller

## Testing
- `go test ./...` *(fails: fetching modules from storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684d78ecf36c833183616009c19836c5